### PR TITLE
Add script:eval() function extension to evaluate an expression

### DIFF
--- a/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.script.js;
+
+import io.siddhi.annotation.Example;
+import io.siddhi.annotation.Extension;
+import io.siddhi.annotation.Parameter;
+import io.siddhi.annotation.ParameterOverload;
+import io.siddhi.annotation.ReturnAttribute;
+import io.siddhi.annotation.util.DataType;
+import io.siddhi.core.config.SiddhiQueryContext;
+import io.siddhi.core.exception.SiddhiAppRuntimeException;
+import io.siddhi.core.executor.ConstantExpressionExecutor;
+import io.siddhi.core.executor.ExpressionExecutor;
+import io.siddhi.core.executor.function.FunctionExecutor;
+import io.siddhi.core.util.config.ConfigReader;
+import io.siddhi.core.util.snapshot.state.State;
+import io.siddhi.core.util.snapshot.state.StateFactory;
+import io.siddhi.query.api.definition.Attribute;
+import io.siddhi.query.api.exception.SiddhiAppValidationException;
+import jdk.nashorn.internal.runtime.ParserException;
+
+import java.util.Locale;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+import static io.siddhi.query.api.definition.Attribute.Type.STRING;
+
+/**
+ * eval(string, dataType)
+ * Evaluate the string and return output as dataType
+ * Accept Type(s): (STRING, STRING)
+ * Return Type(s): STRING/INT/LONG/FLOAT/DOUBLE/BOOL
+ */
+@Extension(
+        name = "eval",
+        namespace = "script",
+        description = "This extension evaluated a given string and " +
+                "return the output according to the user specified data type.",
+        parameters = {
+                @Parameter(name = "expression",
+                        description = "The string with an logical or arithmetic expression.",
+                        type = {DataType.STRING},
+                        dynamic = true),
+                @Parameter(name = "data.type",
+                        description = "The return type of the evaluated expression." +
+                                " Supported types are int/long/float/double/bool/string.",
+                        type = {DataType.STRING},
+                        dynamic = true),
+        },
+        parameterOverloads = {
+                @ParameterOverload(parameterNames = {"expression", "data.type"})
+        },
+        returnAttributes =
+        @ReturnAttribute(
+                description = "The output of the evaluated expression.",
+                type = {DataType.INT, DataType.LONG, DataType.DOUBLE, DataType.FLOAT,
+                        DataType.STRING, DataType.BOOL, DataType.OBJECT}),
+        examples =
+        @Example(
+                syntax = "script:eval(\"700 > 800\", 'bool')",
+                description = "" +
+                        "In this example, the expression 700 > 800 will be evaluated and " +
+                        "return result as false because user specified return type as bool.")
+)
+public class EvalFunctionExtension extends FunctionExecutor {
+
+    private static final String ENGINE_NAME = "nashorn";
+    private ScriptEngine engine;
+    private Attribute.Type returnType = Attribute.Type.OBJECT;
+
+    @Override
+    protected StateFactory<State> init(ExpressionExecutor[] expressionExecutors,
+                                       ConfigReader configReader,
+                                       SiddhiQueryContext siddhiQueryContext) {
+        int executorsCount = expressionExecutors.length;
+
+        if (executorsCount != 2) {
+            throw new SiddhiAppValidationException("Invalid number of arguments passed to "
+                    + "script:eval() function. Required exactly 2, but found " + executorsCount);
+        }
+        ExpressionExecutor executor1 = expressionExecutors[0];
+        ExpressionExecutor executor2 = expressionExecutors[1];
+
+        if (executor1.getReturnType() != STRING) {
+            throw new SiddhiAppValidationException("Invalid parameter type found for the first argument of "
+                    + "script:eval()() function, required " + STRING.toString() + ", but found "
+                    + executor1.getReturnType().toString());
+
+        }
+        if (!(executor2 instanceof ConstantExpressionExecutor)) {
+            throw new SiddhiAppValidationException("The second argument has to be a string constant specifying " +
+                    "one of the supported data types "
+                    + "(int, long, float, double, string, bool)");
+        } else {
+            String type = attributeExpressionExecutors[1].execute(null).toString();
+            switch (type.toLowerCase(Locale.ENGLISH)) {
+                case "int":
+                    returnType = Attribute.Type.INT;
+                    break;
+                case "long":
+                    returnType = Attribute.Type.LONG;
+                    break;
+                case "float":
+                    returnType = Attribute.Type.FLOAT;
+                    break;
+                case "double":
+                    returnType = Attribute.Type.DOUBLE;
+                    break;
+                case "bool":
+                    returnType = Attribute.Type.BOOL;
+                    break;
+                case "string":
+                    returnType = Attribute.Type.STRING;
+                    break;
+                default:
+                    throw new SiddhiAppValidationException("Type must be one of int, long, float, double, bool, " +
+                            "string");
+            }
+        }
+        engine = new ScriptEngineManager().getEngineByName(ENGINE_NAME);
+        return null;
+    }
+
+    @Override
+    protected Object execute(Object[] objects, State state) {
+        String expressionString = (String) objects[0];
+        Object result;
+        try {
+            result = engine.eval(expressionString);
+        } catch (ScriptException | ParserException e) {
+            throw new SiddhiAppRuntimeException(
+                    "Error evaluating the given script " + expressionString, e);
+        }
+        return result;
+    }
+
+    @Override
+    protected Object execute(Object o, State state) {
+        return null;
+    }
+
+    @Override
+    public Attribute.Type getReturnType() {
+        return returnType;
+    }
+}

--- a/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
@@ -56,17 +56,16 @@ import static io.siddhi.query.api.definition.Attribute.Type.STRING;
                 "return the output according to the user specified data type.",
         parameters = {
                 @Parameter(name = "expression",
-                        description = "The string with an logical or arithmetic expression.",
+                        description = "Any single line js expression or function.",
                         type = {DataType.STRING},
                         dynamic = true),
-                @Parameter(name = "data.type",
+                @Parameter(name = "return.type",
                         description = "The return type of the evaluated expression." +
-                                " Supported types are int/long/float/double/bool/string.",
-                        type = {DataType.STRING},
-                        dynamic = true),
+                                " Supported types are int|long|float|double|bool|string.",
+                        type = {DataType.STRING}),
         },
         parameterOverloads = {
-                @ParameterOverload(parameterNames = {"expression", "data.type"})
+                @ParameterOverload(parameterNames = {"expression", "return.type"})
         },
         returnAttributes =
         @ReturnAttribute(
@@ -133,8 +132,9 @@ public class EvalFunctionExtension extends FunctionExecutor {
                     returnType = Attribute.Type.STRING;
                     break;
                 default:
-                    throw new SiddhiAppValidationException("Type must be one of int, long, float, double, bool, " +
-                            "string");
+                    throw new SiddhiAppValidationException("Invalid return type found: Return types" +
+                            " supported by script:eval() function are int, long, float, double, bool " +
+                            "and string");
             }
         }
         engine = new ScriptEngineManager().getEngineByName(ENGINE_NAME);

--- a/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
@@ -132,6 +132,12 @@ public class EvalFunctionExtension extends FunctionExecutor {
                         "and string");
         }
         engine = new ScriptEngineManager().getEngineByName(ENGINE_NAME);
+        if (engine ==  null) {
+            throw new SiddhiAppRuntimeException(
+                    "Error evaluating the given expression in js:eval(), " +
+                            "the script engine manager should not be null"
+            );
+        }
         return null;
     }
 
@@ -139,12 +145,6 @@ public class EvalFunctionExtension extends FunctionExecutor {
     protected Object execute(Object[] objects, State state) {
         String expressionString = (String) objects[0];
         Object result;
-        if (engine ==  null) {
-            throw new SiddhiAppRuntimeException(
-                    "Error evaluating the given expression " + expressionString + " in js:eval(), " +
-                            "the script engine manager should not be null"
-            );
-        }
         try {
             result = engine.eval(expressionString);
         } catch (ScriptException | ParserException e) {

--- a/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
@@ -135,7 +135,7 @@ public class EvalFunctionExtension extends FunctionExecutor {
         if (engine ==  null) {
             throw new SiddhiAppRuntimeException(
                     "Error evaluating the given expression in js:eval(), " +
-                            "the script engine manager should not be null"
+                            "failed to initialize script engine"
             );
         }
         return null;

--- a/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/script/js/EvalFunctionExtension.java
@@ -44,7 +44,7 @@ import javax.script.ScriptException;
 import static io.siddhi.query.api.definition.Attribute.Type.STRING;
 
 /**
- * eval(string, dataType)
+ * eval(expression, dataType)
  * Evaluate the string and return output as dataType
  * Accept Type(s): (STRING, STRING)
  * Return Type(s): STRING/INT/LONG/FLOAT/DOUBLE/BOOL
@@ -52,7 +52,7 @@ import static io.siddhi.query.api.definition.Attribute.Type.STRING;
 @Extension(
         name = "eval",
         namespace = "script",
-        description = "This extension evaluated a given string and " +
+        description = "This extension evaluates a given string and " +
                 "return the output according to the user specified data type.",
         parameters = {
                 @Parameter(name = "expression",
@@ -110,7 +110,9 @@ public class EvalFunctionExtension extends FunctionExecutor {
                     "one of the supported data types "
                     + "(int, long, float, double, string, bool)");
         } else {
-            String type = attributeExpressionExecutors[1].execute(null).toString();
+            ConstantExpressionExecutor constantExpressionExecutor =
+                    (ConstantExpressionExecutor) attributeExpressionExecutors[1];
+            String type = String.valueOf(constantExpressionExecutor.getValue());
             switch (type.toLowerCase(Locale.ENGLISH)) {
                 case "int":
                     returnType = Attribute.Type.INT;

--- a/component/src/test/java/io/siddhi/extension/script/js/EvalFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/script/js/EvalFunctionExtensionTestCase.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.script.js;
+
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.exception.SiddhiAppCreationException;
+import io.siddhi.core.query.output.callback.QueryCallback;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.extension.script.js.test.util.SiddhiTestHelper;
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class EvalFunctionExtensionTestCase {
+
+    private static final Logger log = Logger.getLogger(EvalScriptTestCase.class);
+    private AtomicInteger count = new AtomicInteger(0);
+
+    @BeforeMethod
+    public void init() {
+        count.set(0);
+    }
+
+    @Test
+    public void testEvalArithmeticExpression() throws InterruptedException {
+
+        log.info("testEvalArithmeticExpression testing an arithmetic expression evaluation");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
+
+        String concatFunc = "";
+
+        String cseEventStream = "define stream inputStream(executionTemplate string);";
+        String query = ("@info(name = 'query1') from inputStream" +
+                " select script:eval(executionTemplate, 'int') as result " +
+                "insert into outputStream;");
+        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
+                concatFunc + cseEventStream + query);
+
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                Object value = inEvents[inEvents.length - 1].getData(0);
+                AssertJUnit.assertEquals(24, value);
+                count.incrementAndGet();
+            }
+        });
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+
+        inputHandler.send(new Object[]{"7 + 8 + 9"});
+        SiddhiTestHelper.waitForEvents(100, 1, count, 60000);
+        AssertJUnit.assertEquals(1, count.get());
+
+        executionPlanRuntime.shutdown();
+    }
+
+    @Test
+    public void testEvalLogicalExpression() throws InterruptedException {
+
+        log.info("testEvalArithmeticExpression testing a logical expression evaluation");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
+
+        String concatFunc = "";
+
+        String cseEventStream = "define stream inputStream(executionTemplate string);";
+        String query = ("@info(name = 'query1') from inputStream" +
+                " select script:eval(executionTemplate, 'bool') as result " +
+                "insert into outputStream;");
+        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
+                concatFunc + cseEventStream + query);
+
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                Object value = inEvents[inEvents.length - 1].getData(0);
+                AssertJUnit.assertEquals(false, value);
+                count.incrementAndGet();
+            }
+        });
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+
+        inputHandler.send(new Object[]{"7 > 100"});
+        SiddhiTestHelper.waitForEvents(100, 1, count, 60000);
+        AssertJUnit.assertEquals(1, count.get());
+
+        executionPlanRuntime.shutdown();
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class)
+    public void testEvalInvalidArgument() throws InterruptedException {
+
+        log.info("testEvalInvalidExpression testing an invalid argument evaluation");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
+
+        String concatFunc = "";
+
+        String cseEventStream = "define stream inputStream(executionTemplate string);";
+        String query = ("@info(name = 'query1') from inputStream" +
+                " select script:eval(executionTemplate, 'str') as result " +
+                "insert into outputStream;");
+        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
+                concatFunc + cseEventStream + query);
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+
+        inputHandler.send(new Object[]{"7 > 100 && 8 < 0"});
+
+        executionPlanRuntime.shutdown();
+    }
+
+    @Test(expectedExceptions = SiddhiAppCreationException.class)
+    public void testEvalInvalidNumberOfArguments() throws InterruptedException {
+
+        log.info("testEvalInvalidExpression testing an invalid number of evaluation");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
+
+        String concatFunc = "";
+
+        String cseEventStream = "define stream inputStream(executionTemplate string);";
+        String query = ("@info(name = 'query1') from inputStream" +
+                " select script:eval(executionTemplate) as result " +
+                "insert into outputStream;");
+        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
+                concatFunc + cseEventStream + query);
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+
+        inputHandler.send(new Object[]{"7 > 100 && 8 < 0"});
+
+        executionPlanRuntime.shutdown();
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/script/js/EvalFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/script/js/EvalFunctionExtensionTestCase.java
@@ -48,11 +48,11 @@ public class EvalFunctionExtensionTestCase {
         log.info("testEvalArithmeticExpression testing an arithmetic expression evaluation");
 
         SiddhiManager siddhiManager = new SiddhiManager();
-        siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
+        siddhiManager.setExtension("js:eval", EvalFunctionExtension.class);
         String concatFunc = "";
         String cseEventStream = "define stream inputStream(executionTemplate string);";
         String query = ("@info(name = 'query1') from inputStream" +
-                " select script:eval(executionTemplate, 'int') as result " +
+                " select js:eval(executionTemplate, 'int') as result " +
                 "insert into outputStream;");
         SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
                 concatFunc + cseEventStream + query);
@@ -79,11 +79,11 @@ public class EvalFunctionExtensionTestCase {
         log.info("testEvalArithmeticExpression testing a logical expression evaluation");
 
         SiddhiManager siddhiManager = new SiddhiManager();
-        siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
+        siddhiManager.setExtension("js:eval", EvalFunctionExtension.class);
         String concatFunc = "";
         String cseEventStream = "define stream inputStream(executionTemplate string);";
         String query = ("@info(name = 'query1') from inputStream" +
-                " select script:eval(executionTemplate, 'bool') as result " +
+                " select js:eval(executionTemplate, 'bool') as result " +
                 "insert into outputStream;");
 
         SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
@@ -110,11 +110,11 @@ public class EvalFunctionExtensionTestCase {
         log.info("testEvalInvalidExpression testing an invalid argument evaluation");
 
         SiddhiManager siddhiManager = new SiddhiManager();
-        siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
+        siddhiManager.setExtension("js:eval", EvalFunctionExtension.class);
         String concatFunc = "";
         String cseEventStream = "define stream inputStream(executionTemplate string);";
         String query = ("@info(name = 'query1') from inputStream" +
-                " select script:eval(executionTemplate, 'str') as result " +
+                " select js:eval(executionTemplate, 'str') as result " +
                 "insert into outputStream;");
 
         SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
@@ -130,11 +130,11 @@ public class EvalFunctionExtensionTestCase {
         log.info("testEvalInvalidExpression testing an invalid number of evaluation");
 
         SiddhiManager siddhiManager = new SiddhiManager();
-        siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
+        siddhiManager.setExtension("js:eval", EvalFunctionExtension.class);
         String concatFunc = "";
         String cseEventStream = "define stream inputStream(executionTemplate string);";
         String query = ("@info(name = 'query1') from inputStream" +
-                " select script:eval(executionTemplate) as result " +
+                " select js:eval(executionTemplate) as result " +
                 "insert into outputStream;");
 
         SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(

--- a/component/src/test/java/io/siddhi/extension/script/js/EvalFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/script/js/EvalFunctionExtensionTestCase.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class EvalFunctionExtensionTestCase {
 
-    private static final Logger log = Logger.getLogger(EvalScriptTestCase.class);
+    private static final Logger log = Logger.getLogger(EvalFunctionExtensionTestCase.class);
     private AtomicInteger count = new AtomicInteger(0);
 
     @BeforeMethod
@@ -45,21 +45,17 @@ public class EvalFunctionExtensionTestCase {
 
     @Test
     public void testEvalArithmeticExpression() throws InterruptedException {
-
         log.info("testEvalArithmeticExpression testing an arithmetic expression evaluation");
 
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
-
         String concatFunc = "";
-
         String cseEventStream = "define stream inputStream(executionTemplate string);";
         String query = ("@info(name = 'query1') from inputStream" +
                 " select script:eval(executionTemplate, 'int') as result " +
                 "insert into outputStream;");
         SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
                 concatFunc + cseEventStream + query);
-
         executionPlanRuntime.addCallback("query1", new QueryCallback() {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
@@ -72,31 +68,26 @@ public class EvalFunctionExtensionTestCase {
 
         InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
         executionPlanRuntime.start();
-
         inputHandler.send(new Object[]{"7 + 8 + 9"});
         SiddhiTestHelper.waitForEvents(100, 1, count, 60000);
         AssertJUnit.assertEquals(1, count.get());
-
         executionPlanRuntime.shutdown();
     }
 
     @Test
     public void testEvalLogicalExpression() throws InterruptedException {
-
         log.info("testEvalArithmeticExpression testing a logical expression evaluation");
 
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
-
         String concatFunc = "";
-
         String cseEventStream = "define stream inputStream(executionTemplate string);";
         String query = ("@info(name = 'query1') from inputStream" +
                 " select script:eval(executionTemplate, 'bool') as result " +
                 "insert into outputStream;");
+
         SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
                 concatFunc + cseEventStream + query);
-
         executionPlanRuntime.addCallback("query1", new QueryCallback() {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
@@ -106,64 +97,51 @@ public class EvalFunctionExtensionTestCase {
                 count.incrementAndGet();
             }
         });
-
         InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
         executionPlanRuntime.start();
-
         inputHandler.send(new Object[]{"7 > 100"});
         SiddhiTestHelper.waitForEvents(100, 1, count, 60000);
         AssertJUnit.assertEquals(1, count.get());
-
         executionPlanRuntime.shutdown();
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class)
     public void testEvalInvalidArgument() throws InterruptedException {
-
         log.info("testEvalInvalidExpression testing an invalid argument evaluation");
 
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
-
         String concatFunc = "";
-
         String cseEventStream = "define stream inputStream(executionTemplate string);";
         String query = ("@info(name = 'query1') from inputStream" +
                 " select script:eval(executionTemplate, 'str') as result " +
                 "insert into outputStream;");
+
         SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
                 concatFunc + cseEventStream + query);
-
         InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
         executionPlanRuntime.start();
-
         inputHandler.send(new Object[]{"7 > 100 && 8 < 0"});
-
         executionPlanRuntime.shutdown();
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class)
     public void testEvalInvalidNumberOfArguments() throws InterruptedException {
-
         log.info("testEvalInvalidExpression testing an invalid number of evaluation");
 
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setExtension("script:eval", EvalFunctionExtension.class);
-
         String concatFunc = "";
-
         String cseEventStream = "define stream inputStream(executionTemplate string);";
         String query = ("@info(name = 'query1') from inputStream" +
                 " select script:eval(executionTemplate) as result " +
                 "insert into outputStream;");
+
         SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(
                 concatFunc + cseEventStream + query);
-
         InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
         executionPlanRuntime.start();
-
         inputHandler.send(new Object[]{"7 > 100 && 8 < 0"});
-
         executionPlanRuntime.shutdown();
     }
 }

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -18,6 +18,7 @@ limitations under the License.
     <test name="Siddhi-script-js-tests" preserve-order="true" parallel="false">
         <classes>
             <class name="io.siddhi.extension.script.js.EvalScriptTestCase"/>
+            <class name="io.siddhi.extension.script.js.EvalFunctionExtensionTestCase"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
- Resolve https://github.com/siddhi-io/siddhi-execution-string/issues/61
- We have to change this functionality if we fix this issue https://github.com/siddhi-io/siddhi-script-js/issues/41.
## Goals
To evaluate dynamic expressions like follow that given as a string.
- 800 > 900
- 500 * 400 + 90

## Approach
Receive expression as a string and using the nashorn script engine evaluate the expression and return the result to the user.

## User stories
User can specify extension like below.

### Example 01
**Input**
```sql
script:eval("700 > 800", 'bool')
```
**Output**
false

### Example 02
**Input**
```sql
script:eval("700 + 800", 'int')
```
**Output**
1500

## Release note
Add new extension script:eval(STRING, STRING) -> STRING/INT/LONG/FLOAT/DOUBLE/BOOL

## Automation tests
 - Unit tests 
   > Add test cases to evaluate arithmetic and logical expressions and check the validation of the extension.

## Related PRs
https://github.com/siddhi-io/siddhi-execution-string/pull/62

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
